### PR TITLE
Improve accessibility of switch

### DIFF
--- a/bootstrap-switch.js
+++ b/bootstrap-switch.js
@@ -45,7 +45,12 @@
 
 		return this.each(function(e) {
 			var c = $(this);
-			var disabled = c.is(":disabled") ? " disabled" : "";
+			var disabled = c.is(':disabled') ? ' disabled' : '';
+
+			// Remove the ability to tab to the secondary (white) toggle button.
+			var tabindex = ' tabindex="-1"',
+			// Hide second button from screen readers.
+			    aria = ' aria-hidden="true"'; 
 
 			var div = $('<div class="btn-group btn-toggle" style="white-space: nowrap;"></div>').insertAfter(this);
 			var on = $('<button class="btn btn-primary '+settings.size+disabled+'" style="float: none;display: inline-block;"></button>').html(settings.on).css('margin-right', '0px').appendTo(div);
@@ -63,8 +68,8 @@
 			}
 			applyChange(c.is(':checked'));
 
-			on.click(function(e) {e.preventDefault();c.prop("checked", !c.prop("checked")).trigger('change')});
-			off.click(function(e) {e.preventDefault();c.prop("checked", !c.prop("checked")).trigger('change')});
+			on.click(function(e) {e.preventDefault();c.prop('checked', !c.prop('checked')).trigger('change')});
+			off.click(function(e) {e.preventDefault();c.prop('checked', !c.prop('checked')).trigger('change')});
 
 			$(this).hide().on('change', function() {
 				applyChange(c.is(':checked'))


### PR DESCRIPTION
The current toggle switches are an accessibility nightmare to use. This is a minor improvement, but more work could be done. Pull request also normalises the use of single quote / double quote.

* Add a negative tab index for the second button
* Use an `aria-hidden` attribute to hide second button from screen readers
* Normalise use of quotes.